### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ There were 1016 tricks
 
 Rucklidge 2014:
 Starting hands: -J------Q------AAA-----QQ-/K----JA-----------KQ-K-JJK
-There were 7960 turns
+There were 7959 turns
 There were 1122 tricks
 ````

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Output:
 ````
 Paulhus 1999:
 Starting hands: ------------KAQ----J------/-JQQK---K----JK--QA-A-JA--
-There were 4792 turns
+There were 4791 turns
 There were 670 tricks
 
 Kleber 1999:
 Starting hands: ---JQ---K-A----A-J-K---QK-/-J-----------AJQA----K---Q
-There were 5791 turns
+There were 5790 turns
 There were 805 tricks
 
 Collins 2006:
 Starting hands: A-QK------Q----KA-----J---/-JAK----A--Q----J---QJ--K-
-There were 6914 turns
+There were 6913 turns
 There were 960 tricks
 
 Mann and Wu 2007:

--- a/beggarmypython/__init__.py
+++ b/beggarmypython/__init__.py
@@ -16,7 +16,6 @@ def play(hands,firstCardOnLeft=True,verbose=False):
         battle_in_progress = False
         cards_to_play = 1
         while cards_to_play>0: #current player may play up to cards_to_play cards
-            turns=turns+1
             
             try:
                 if player==1:
@@ -29,6 +28,8 @@ def play(hands,firstCardOnLeft=True,verbose=False):
                     b = b[1:]
             except IndexError:
                 break #ran out of cards to play, game over...
+			
+            turns=turns+1
             
             stack = stack+next_card #add to the stack
             

--- a/test.py
+++ b/test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 import beggarmypython
 
+#test
+
 print "Paulhus 1999:"
 beggarmypython.play(('------------KAQ----J------','-JQQK---K----JK--QA-A-JA--'),verbose=False)
 

--- a/test.py
+++ b/test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 import beggarmypython
 
-#test
-
 print "Paulhus 1999:"
 beggarmypython.play(('------------KAQ----J------','-JQQK---K----JK--QA-A-JA--'),verbose=False)
 

--- a/test_issue_1.py
+++ b/test_issue_1.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+import beggarmypython
+
+print "Issue #1 - should be 52 plays:"
+beggarmypython.play(('--------------------------','--------------------------'), verbose=False)
+
+print "Anderson 2013 - should be 7225 turns (as before fix):"
+beggarmypython.play(('--A-Q--J--J---Q--AJ-K---K-','-J-------Q------A--A--QKK-'),verbose=False)
+
+print "Rucklidge 2014 - should be 7959 plays:"
+beggarmypython.play(('-J------Q------AAA-----QQ-','K----JA-----------KQ-K-JJK'), verbose=False)


### PR DESCRIPTION
Increment turn count only after checking if there are cards to play. It is mistakenly incrementing by more than it should because of the 'while cards_to_play>0' loop. Some records reduced by 1 in README. Should resolve #1 - dedicated test included.